### PR TITLE
feat: record quiz time taken

### DIFF
--- a/frontend/src/components/Quiz.vue
+++ b/frontend/src/components/Quiz.vue
@@ -343,6 +343,8 @@ let questions = reactive([])
 const possibleAnswer = ref(null)
 const timer = ref(0)
 let timerInterval = null
+let startTime = null
+const timeTaken = ref(0)
 
 const props = defineProps({
 	quizName: {
@@ -479,13 +481,14 @@ watch(
 )
 
 const quizSubmission = createResource({
-	url: 'lms.lms.doctype.lms_quiz.lms_quiz.quiz_summary',
-	makeParams(values) {
-		return {
-			quiz: quiz.data.name,
-			results: localStorage.getItem(quiz.data.title),
-		}
-	},
+        url: 'lms.lms.doctype.lms_quiz.lms_quiz.quiz_summary',
+        makeParams(values) {
+                return {
+                        quiz: quiz.data.name,
+                        results: localStorage.getItem(quiz.data.title),
+                        time_taken: timeTaken.value,
+                }
+        },
 })
 
 const questionDetails = createResource({
@@ -514,9 +517,10 @@ watch(
 )
 
 const startQuiz = () => {
-	activeQuestion.value = 1
-	localStorage.removeItem(quiz.data.title)
-	if (quiz.data.duration) startTimer()
+        activeQuestion.value = 1
+        localStorage.removeItem(quiz.data.title)
+        startTime = Date.now()
+        if (quiz.data.duration) startTimer()
 }
 
 const markAnswer = (index) => {
@@ -646,9 +650,10 @@ const submitQuiz = () => {
 }
 
 const createSubmission = () => {
-	quizSubmission.submit(
-		{},
-		{
+        timeTaken.value = startTime ? (Date.now() - startTime) / 1000 : 0
+        quizSubmission.submit(
+                {},
+                {
 			onSuccess(data) {
 				markLessonProgress()
 				if (quiz.data && quiz.data.max_attempts) attempts.reload()
@@ -669,12 +674,14 @@ const createSubmission = () => {
 }
 
 const resetQuiz = () => {
-	activeQuestion.value = 0
-	selectedOptions.splice(0, selectedOptions.length, ...[0, 0, 0, 0])
-	showAnswers.length = 0
-	quizSubmission.reset()
-	populateQuestions()
-	setupTimer()
+        activeQuestion.value = 0
+        selectedOptions.splice(0, selectedOptions.length, ...[0, 0, 0, 0])
+        showAnswers.length = 0
+        quizSubmission.reset()
+        populateQuestions()
+        setupTimer()
+        startTime = null
+        timeTaken.value = 0
 }
 
 const getInstructions = (question) => {

--- a/lms/lms/doctype/lms_quiz/lms_quiz.py
+++ b/lms/lms/doctype/lms_quiz/lms_quiz.py
@@ -98,9 +98,9 @@ def set_total_marks(questions):
 
 
 @frappe.whitelist()
-def quiz_summary(quiz, results):
-	results = results and json.loads(results)
-	percentage = 0
+def quiz_summary(quiz, results, time_taken=None):
+        results = results and json.loads(results)
+        percentage = 0
 
 	quiz_details = frappe.db.get_value(
 		"LMS Quiz",
@@ -124,7 +124,9 @@ def quiz_summary(quiz, results):
 
 	score_out_of = quiz_details.total_marks
 	percentage = (score / score_out_of) * 100 if score_out_of else 0
-	submission = create_submission(quiz, results, score_out_of, quiz_details.passing_percentage)
+        submission = create_submission(
+                quiz, results, score_out_of, quiz_details.passing_percentage, time_taken
+        )
 
 	save_progress_after_quiz(quiz_details, percentage)
 
@@ -228,23 +230,24 @@ def get_corrupted_image_msg():
 	return _("Image: Corrupted Data Stream")
 
 
-def create_submission(quiz, results, score_out_of, passing_percentage):
-	submission = frappe.new_doc("LMS Quiz Submission")
-	# Score and percentage are calculated by the controller function
-	submission.update(
-		{
-			"doctype": "LMS Quiz Submission",
-			"quiz": quiz,
-			"result": results,
-			"score": 0,
-			"score_out_of": score_out_of,
-			"member": frappe.session.user,
-			"percentage": 0,
-			"passing_percentage": passing_percentage,
-		}
-	)
-	submission.save(ignore_permissions=True)
-	return submission
+def create_submission(quiz, results, score_out_of, passing_percentage, time_taken=None):
+        submission = frappe.new_doc("LMS Quiz Submission")
+        # Score and percentage are calculated by the controller function
+        submission.update(
+                {
+                        "doctype": "LMS Quiz Submission",
+                        "quiz": quiz,
+                        "result": results,
+                        "score": 0,
+                        "score_out_of": score_out_of,
+                        "member": frappe.session.user,
+                        "percentage": 0,
+                        "passing_percentage": passing_percentage,
+                        "time_taken": time_taken,
+                }
+        )
+        submission.save(ignore_permissions=True)
+        return submission
 
 
 def save_progress_after_quiz(quiz_details, percentage):

--- a/lms/lms/doctype/lms_quiz_submission/lms_quiz_submission.json
+++ b/lms/lms/doctype/lms_quiz_submission/lms_quiz_submission.json
@@ -17,6 +17,7 @@
   "column_break_gkip",
   "percentage",
   "passing_percentage",
+  "time_taken",
   "section_break_6",
   "result"
  ],
@@ -104,6 +105,12 @@
    "non_negative": 1,
    "read_only": 1,
    "reqd": 1
+  },
+  {
+   "fieldname": "time_taken",
+   "fieldtype": "Float",
+   "label": "Time Taken",
+   "read_only": 1
   },
   {
    "fetch_from": "quiz.title",


### PR DESCRIPTION
## Summary
- track quiz duration on the client and send time taken with submission
- store time taken on LMS Quiz Submission
- add `time_taken` field to quiz submissions

## Testing
- `pytest` *(fails: 35 errors during collection)*


------
https://chatgpt.com/codex/tasks/task_e_68c00948ce308329a4c6d8e191963537