### PR TITLE
feat: show quiz statistics after submission

### DIFF
--- a/frontend/src/components/Quiz.vue
+++ b/frontend/src/components/Quiz.vue
@@ -295,26 +295,59 @@
 					)
 				}}
 			</div>
-			<div v-else>
-				{{
-					__(
-						'You got {0}% correct answers with a score of {1} out of {2}',
-					).format(
-						Math.ceil(quizSubmission.data.percentage),
-						quizSubmission.data.score,
-						quizSubmission.data.score_out_of,
-					)
-				}}
-			</div>
-			<div class="space-x-2">
-				<Button
-					@click="resetQuiz()"
-					class="mt-2"
-					v-if="
-						!quiz.data.max_attempts ||
-						attempts?.data.length < quiz.data.max_attempts
-					"
-				>
+                        <div v-else>
+                                {{
+                                        __(
+                                                'You got {0}% correct answers with a score of {1} out of {2}',
+                                        ).format(
+                                                Math.ceil(quizSubmission.data.percentage),
+                                                quizSubmission.data.score,
+                                                quizSubmission.data.score_out_of,
+                                        )
+                                }}
+                        </div>
+                        <div
+                                v-if="quizSubmission.data.stats"
+                                class="mt-4 border-t pt-4 text-sm grid grid-cols-2 gap-y-1 text-left"
+                        >
+                                <div class="text-ink-gray-7">{{ __('Number of Students') }}</div>
+                                <div class="text-right">
+                                        {{ quizSubmission.data.stats.custom_n_total }}
+                                </div>
+                                <div class="text-ink-gray-7">{{ __('Total Attempts') }}</div>
+                                <div class="text-right">
+                                        {{ quizSubmission.data.stats.custom_total_attempts }}
+                                </div>
+                                <div class="text-ink-gray-7">{{ __('Overall P-value (Difficulty)') }}</div>
+                                <div class="text-right">
+                                        {{ quizSubmission.data.stats.custom_p_value }}
+                                </div>
+                                <div class="text-ink-gray-7">{{ __('Pass Rate (%)') }}</div>
+                                <div class="text-right">
+                                        {{ quizSubmission.data.stats.custom_pass_rate }}
+                                </div>
+                                <div class="text-ink-gray-7">{{ __('Mean Score') }}</div>
+                                <div class="text-right">
+                                        {{ quizSubmission.data.stats.custom_mean_score }}
+                                </div>
+                                <div class="text-ink-gray-7">{{ __('Score Standard Deviation') }}</div>
+                                <div class="text-right">
+                                        {{ quizSubmission.data.stats.custom_sd_score }}
+                                </div>
+                                <div class="text-ink-gray-7">{{ __('Last Stat Update') }}</div>
+                                <div class="text-right">
+                                        {{ quizSubmission.data.stats.custom_last_stat_update }}
+                                </div>
+                        </div>
+                        <div class="space-x-2">
+                                <Button
+                                        @click="resetQuiz()"
+                                        class="mt-2"
+                                        v-if="
+                                                !quiz.data.max_attempts ||
+                                                attempts?.data.length < quiz.data.max_attempts
+                                        "
+                                >
 					<span>
 						{{ __('Try Again') }}
 					</span>

--- a/frontend/src/components/Quiz.vue
+++ b/frontend/src/components/Quiz.vue
@@ -310,14 +310,6 @@
                                 v-if="quizSubmission.data.stats"
                                 class="mt-4 border-t pt-4 text-sm grid grid-cols-2 gap-y-1 text-left"
                         >
-                                <div class="text-ink-gray-7">{{ __('Number of Students') }}</div>
-                                <div class="text-right">
-                                        {{ quizSubmission.data.stats.custom_n_total }}
-                                </div>
-                                <div class="text-ink-gray-7">{{ __('Total Attempts') }}</div>
-                                <div class="text-right">
-                                        {{ quizSubmission.data.stats.custom_total_attempts }}
-                                </div>
                                 <div class="text-ink-gray-7">{{ __('Overall P-value (Difficulty)') }}</div>
                                 <div class="text-right">
                                         {{ quizSubmission.data.stats.custom_p_value }}

--- a/lms/lms/doctype/lms_quiz/lms_quiz.py
+++ b/lms/lms/doctype/lms_quiz/lms_quiz.py
@@ -113,6 +113,13 @@ def quiz_summary(quiz, results, time_taken=None):
 			"course",
 			"enable_negative_marking",
 			"marks_to_cut",
+			"custom_n_total",
+			"custom_total_attempts",
+			"custom_p_value",
+			"custom_pass_rate",
+			"custom_mean_score",
+			"custom_sd_score",
+			"custom_last_stat_update",
 		],
 		as_dict=1,
 	)
@@ -130,6 +137,16 @@ def quiz_summary(quiz, results, time_taken=None):
 
 	save_progress_after_quiz(quiz_details, percentage)
 
+	stats = {
+		"custom_n_total": quiz_details.custom_n_total,
+		"custom_total_attempts": quiz_details.custom_total_attempts,
+		"custom_p_value": quiz_details.custom_p_value,
+		"custom_pass_rate": quiz_details.custom_pass_rate,
+		"custom_mean_score": quiz_details.custom_mean_score,
+		"custom_sd_score": quiz_details.custom_sd_score,
+		"custom_last_stat_update": quiz_details.custom_last_stat_update,
+	}
+
 	return {
 		"score": score,
 		"score_out_of": score_out_of,
@@ -137,6 +154,7 @@ def quiz_summary(quiz, results, time_taken=None):
 		"pass": percentage == quiz_details.passing_percentage,
 		"percentage": percentage,
 		"is_open_ended": is_open_ended,
+		"stats": stats,
 	}
 
 


### PR DESCRIPTION
## Summary
- include quiz-wide statistics in summary API response
- display aggregated quiz stats on the quiz result page

## Testing
- `python -m py_compile lms/lms/doctype/lms_quiz/lms_quiz.py`
- `pre-commit run --files lms/lms/doctype/lms_quiz/lms_quiz.py frontend/src/components/Quiz.vue` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c186cd95008329a2aff2c5b705f8ca