### PR TITLE
feat: show assignment submission summary on batch page

### DIFF
--- a/frontend/src/components/Assessments.vue
+++ b/frontend/src/components/Assessments.vue
@@ -11,12 +11,12 @@
 				{{ __('Add') }}
 			</Button>
 		</div>
-		<div v-if="assessments.data?.length" class="text-sm">
-			<ListView
-				:columns="getAssessmentColumns()"
-				:rows="assessments.data"
-				row-key="name"
-				:options="{
+                <div v-if="assessments.data?.length" class="text-sm">
+                        <ListView
+                                :columns="getAssessmentColumns()"
+                                :rows="assessments.data"
+                                row-key="name"
+                                :options="{
 					showTooltip: false,
 					getRowRoute: (row) => getRowRoute(row),
 					selectable: user.data?.is_student ? false : true,
@@ -38,18 +38,33 @@
 				<ListRows>
 					<ListRow :row="row" v-for="row in assessments.data">
 						<template #default="{ column, item }">
-							<ListRowItem :item="row[column.key]" :align="column.align">
-								<div v-if="column.key == 'assessment_type'">
-									{{ getAssessmentTypeLabel(row[column.key]) }}
-								</div>
-								<div v-else-if="column.key == 'title'">
-									{{ row[column.key] }}
-								</div>
-								<div v-else-if="isNaN(row[column.key])">
-									<Badge :theme="getStatusTheme(row[column.key])">
-										{{ row[column.key] }}
-									</Badge>
-								</div>
+                                                        <ListRowItem :item="row[column.key]" :align="column.align">
+                                                                <div v-if="column.key == 'assessment_type'">
+                                                                        {{ getAssessmentTypeLabel(row[column.key]) }}
+                                                                </div>
+                                                                <div v-else-if="column.key == 'title'">
+                                                                        {{ row[column.key] }}
+                                                                </div>
+                                                                <div
+                                                                        v-else-if="
+                                                                                ['submitted_count', 'pending_feedback_count'].includes(
+                                                                                        column.key
+                                                                                )
+                                                                        "
+                                                                        class="text-center"
+                                                                >
+                                                                        <span
+                                                                                v-if="row.assessment_type == 'LMS Assignment'"
+                                                                        >
+                                                                                {{ row[column.key] ?? 0 }}
+                                                                        </span>
+                                                                        <span v-else>—</span>
+                                                                </div>
+                                                                <div v-else-if="isNaN(row[column.key])">
+                                                                        <Badge :theme="getStatusTheme(row[column.key])">
+                                                                                {{ row[column.key] }}
+                                                                        </Badge>
+                                                                </div>
 								<div v-else>
 									{{ row[column.key] }}
 								</div>
@@ -103,7 +118,7 @@ const showModal = ref(false)
 const readOnlyMode = window.read_only_mode
 
 const props = defineProps({
-	batch: {
+        batch: {
 		type: String,
 		required: true,
 	},
@@ -124,28 +139,32 @@ const props = defineProps({
 })
 
 const assessments = createResource({
-	url: 'lms.lms.utils.get_assessments',
-	params: {
-		batch: props.batch,
-	},
-	auto: true,
+        url: 'lms.lms.utils.get_assessments',
+        params: {
+                batch: props.batch,
+        },
+        auto: true,
 })
 
+const canReviewAssessments = () => {
+        return user.data?.is_moderator || user.data?.is_instructor || user.data?.is_evaluator
+}
+
 const deleteAssessments = createResource({
-	url: 'lms.lms.api.delete_documents',
-	makeParams(values) {
-		return {
-			doctype: 'LMS Assessment',
+        url: 'lms.lms.api.delete_documents',
+        makeParams(values) {
+                return {
+                        doctype: 'LMS Assessment',
 			documents: values.assessments,
 		}
 	},
 })
 
 const removeAssessments = (selections, unselectAll) => {
-	deleteAssessments.submit(
-		{ assessments: Array.from(selections) },
-		{
-			onSuccess(data) {
+        deleteAssessments.submit(
+                { assessments: Array.from(selections) },
+                {
+                        onSuccess(data) {
 				assessments.reload()
 				unselectAll()
 			},
@@ -154,11 +173,35 @@ const removeAssessments = (selections, unselectAll) => {
 }
 
 const getRowRoute = (row) => {
-	if (row.assessment_type == 'LMS Assignment') {
-		if (row.submission) {
-			return {
-				name: 'AssignmentSubmission',
-				params: {
+        if (canReviewAssessments()) {
+                if (row.assessment_type == 'LMS Assignment') {
+                        return {
+                                name: 'AssignmentSubmissionList',
+                                query: {
+                                        assignmentID: row.assessment_name,
+                                },
+                        }
+                } else if (row.assessment_type == 'LMS Quiz') {
+                        return {
+                                name: 'QuizSubmissionList',
+                                params: {
+                                        quizID: row.assessment_name,
+                                },
+                        }
+                } else if (row.assessment_type == 'LMS Programming Exercise') {
+                        return {
+                                name: 'ProgrammingExerciseSubmissions',
+                                query: {
+                                        exercise: row.assessment_name,
+                                },
+                        }
+                }
+        }
+        if (row.assessment_type == 'LMS Assignment') {
+                if (row.submission) {
+                        return {
+                                name: 'AssignmentSubmission',
+                                params: {
 					assignmentID: row.assessment_name,
 					submissionName: row.submission.name,
 				},
@@ -201,13 +244,13 @@ const getRowRoute = (row) => {
 }
 
 const canAddAssessments = () => {
-	if (readOnlyMode) return false
-	return user.data?.is_moderator || user.data?.is_evaluator
+        if (readOnlyMode) return false
+        return user.data?.is_moderator || user.data?.is_evaluator
 }
 
 const getAssessmentColumns = () => {
-	let columns = [
-		{
+        let columns = [
+                {
 			label: 'Assessment',
 			key: 'title',
 			width: '25rem',
@@ -216,18 +259,33 @@ const getAssessmentColumns = () => {
 			label: 'Type',
 			key: 'assessment_type',
 			width: '15rem',
-		},
-	]
+                },
+        ]
 
-	if (!user.data?.is_moderator) {
-		columns.push({
-			label: 'Status/Percentage',
-			key: 'status',
-			align: 'left',
-			width: '10rem',
-		})
-	}
-	return columns
+        if (canReviewAssessments()) {
+                columns.push(
+                        {
+                                label: __('Submitted'),
+                                key: 'submitted_count',
+                                width: '8rem',
+                                align: 'center',
+                        },
+                        {
+                                label: __('Not Graded'),
+                                key: 'pending_feedback_count',
+                                width: '10rem',
+                                align: 'center',
+                        }
+                )
+        } else {
+                columns.push({
+                        label: 'Status/Percentage',
+                        key: 'status',
+                        align: 'left',
+                        width: '10rem',
+                })
+        }
+        return columns
 }
 
 const getStatusTheme = (status) => {

--- a/frontend/src/components/BatchStudents.vue
+++ b/frontend/src/components/BatchStudents.vue
@@ -5,25 +5,17 @@
 				{{ __('Statistics') }}
 			</div>
 		</div>
-		<div class="grid grid-cols-2 md:grid-cols-4 gap-5 mb-8">
-			<NumberChart
-				class="border rounded-md"
-				:config="{ title: __('Students'), value: students.data?.length || 0 }"
-			/>
+                <div class="grid grid-cols-2 md:grid-cols-3 gap-5 mb-8">
+                        <NumberChart
+                                class="border rounded-md"
+                                :config="{ title: __('Students'), value: students.data?.length || 0 }"
+                        />
 
-			<NumberChart
-				class="border rounded-md"
-				:config="{
-					title: __('Certified'),
-					value: certificationCount.data || 0,
-				}"
-			/>
-
-			<NumberChart
-				class="border rounded-md"
-				:config="{
-					title: __('Courses'),
-					value: batch.data.courses?.length || 0,
+                        <NumberChart
+                                class="border rounded-md"
+                                :config="{
+                                        title: __('Courses'),
+                                        value: batch.data.courses?.length || 0,
 				}"
 			/>
 
@@ -424,14 +416,4 @@ watch(students, () => {
 	}
 })
 
-const certificationCount = createResource({
-	url: 'frappe.client.get_count',
-	params: {
-		doctype: 'LMS Certificate',
-		filters: {
-			batch_name: props.batch?.data?.name,
-		},
-	},
-	auto: true,
-})
 </script>

--- a/lms/lms/utils.py
+++ b/lms/lms/utils.py
@@ -1464,26 +1464,86 @@ def get_batch_courses(batch):
 
 @frappe.whitelist()
 def get_assessments(batch, member=None):
-	if not member:
-		member = frappe.session.user
+        if member:
+                return _get_assessments_for_member(batch, member)
 
-	assessments = frappe.get_all(
-		"LMS Assessment",
-		{"parent": batch},
-		["name", "assessment_type", "assessment_name"],
-	)
+        roles = frappe.get_roles(frappe.session.user)
+        is_moderator = "Moderator" in roles
+        is_instructor = "Course Creator" in roles
+        is_evaluator = "Batch Evaluator" in roles
+        is_student = "LMS Student" in roles and not (is_moderator or is_instructor or is_evaluator)
 
-	for assessment in assessments:
-		if assessment.assessment_type == "LMS Assignment":
-			assessment = get_assignment_details(assessment, member)
+        if is_student:
+                return _get_assessments_for_member(batch, frappe.session.user)
 
-		elif assessment.assessment_type == "LMS Quiz":
-			assessment = get_quiz_details(assessment, member)
+        return _get_assessment_overview(batch)
 
-		elif assessment.assessment_type == "LMS Programming Exercise":
-			assessment = get_exercise_details(assessment, member)
 
-	return assessments
+def _get_assessments_for_member(batch, member):
+        assessments = frappe.get_all(
+                "LMS Assessment",
+                {"parent": batch},
+                ["name", "assessment_type", "assessment_name"],
+        )
+
+        for assessment in assessments:
+                if assessment.assessment_type == "LMS Assignment":
+                        assessment = get_assignment_details(assessment, member)
+
+                elif assessment.assessment_type == "LMS Quiz":
+                        assessment = get_quiz_details(assessment, member)
+
+                elif assessment.assessment_type == "LMS Programming Exercise":
+                        assessment = get_exercise_details(assessment, member)
+
+        return assessments
+
+
+def _get_assessment_overview(batch):
+        assessments = frappe.get_all(
+                "LMS Assessment",
+                {"parent": batch},
+                ["name", "assessment_type", "assessment_name"],
+        )
+
+        members = frappe.get_all(
+                "LMS Batch Enrollment", filters={"batch": batch}, pluck="member"
+        )
+        members = members or []
+
+        for assessment in assessments:
+                assessment.submitted_count = 0
+                assessment.pending_feedback_count = 0
+
+                if assessment.assessment_type == "LMS Assignment":
+                        assessment.title = frappe.db.get_value(
+                                "LMS Assignment", assessment.assessment_name, "title"
+                        )
+                        if members:
+                                filters = {
+                                        "assignment": assessment.assessment_name,
+                                        "member": ["in", members],
+                                }
+                                assessment.submitted_count = frappe.db.count(
+                                        "LMS Assignment Submission", filters
+                                )
+                                pending_filters = filters.copy()
+                                pending_filters["status"] = "Not Graded"
+                                assessment.pending_feedback_count = frappe.db.count(
+                                        "LMS Assignment Submission", pending_filters
+                                )
+                elif assessment.assessment_type == "LMS Quiz":
+                        assessment.title = frappe.db.get_value(
+                                "LMS Quiz", assessment.assessment_name, "title"
+                        )
+                elif assessment.assessment_type == "LMS Programming Exercise":
+                        assessment.title = frappe.db.get_value(
+                                "LMS Programming Exercise",
+                                assessment.assessment_name,
+                                "title",
+                        )
+
+        return assessments
 
 
 def get_assignment_details(assessment, member):


### PR DESCRIPTION
## Summary
- remove the certificate statistic from the batch student overview cards
- show moderators and instructors assignment submission and pending feedback counts in the batch assessments list with updated navigation shortcuts
- compute batch-level assignment submission summaries on the backend for privileged users

## Testing
- yarn --cwd frontend build *(fails: requires sites/common_site_config.json)*

------
https://chatgpt.com/codex/tasks/task_e_68d2b9bdeca8832986259221e68a86bd