### PR TITLE
feat: support five-choice quiz questions

### DIFF
--- a/frontend/src/components/Modals/Question.vue
+++ b/frontend/src/components/Modals/Question.vue
@@ -61,11 +61,11 @@
 					>
 						{{ __('Possibilities') }}
 					</div>
-					<div
-						v-if="question.type == 'Choices'"
-						class="grid grid-cols-2 gap-x-8 gap-y-4"
-					>
-						<div v-for="n in 4" class="space-y-4 py-2">
+                                        <div
+                                                v-if="question.type == 'Choices'"
+                                                class="grid grid-cols-2 gap-x-8 gap-y-4"
+                                        >
+                                                <div v-for="n in 5" class="space-y-4 py-2">
 							<FormControl
 								:label="__('Option') + ' ' + n"
 								v-model="question[`option_${n}`]"
@@ -148,14 +148,23 @@ const question = reactive({
 })
 
 const populateFields = () => {
-	let fields = ['option', 'is_correct', 'explanation', 'possibility']
-	let counter = 1
-	fields.forEach((field) => {
-		while (counter <= 4) {
-			question[`${field}_${counter}`] = field === 'is_correct' ? false : null
-			counter++
-		}
-	})
+        const choiceFields = ['option', 'explanation']
+        const choiceFieldCount = 5
+        const possibilityCount = 4
+
+        choiceFields.forEach((field) => {
+                for (let counter = 1; counter <= choiceFieldCount; counter++) {
+                        question[`${field}_${counter}`] = null
+                }
+        })
+
+        for (let counter = 1; counter <= choiceFieldCount; counter++) {
+                question[`is_correct_${counter}`] = false
+        }
+
+        for (let counter = 1; counter <= possibilityCount; counter++) {
+                question[`possibility_${counter}`] = null
+        }
 }
 
 populateFields()
@@ -181,17 +190,13 @@ const questionData = createResource({
 	},
 	auto: false,
 	onSuccess(data) {
-		let counter = 1
-		editMode.value = true
-		Object.keys(data).forEach((key) => {
-			if (Object.hasOwn(question, key)) question[key] = data[key]
-		})
-		while (counter <= 4) {
-			question[`is_correct_${counter}`] = data[`is_correct_${counter}`]
-				? true
-				: false
-			counter++
-		}
+                editMode.value = true
+                Object.keys(data).forEach((key) => {
+                        if (Object.hasOwn(question, key)) question[key] = data[key]
+                })
+                for (let counter = 1; counter <= 5; counter++) {
+                        question[`is_correct_${counter}`] = data[`is_correct_${counter}`] ? true : false
+                }
 		question.marks = props.questionDetail.marks
 	},
 })

--- a/frontend/src/components/Quiz.vue
+++ b/frontend/src/components/Quiz.vue
@@ -150,7 +150,10 @@
 						class="text-ink-gray-9 font-semibold mt-2 leading-5"
 						v-html="questionDetails.data.question"
 					></div>
-					<div v-if="questionDetails.data.type == 'Choices'" v-for="index in 4">
+                                        <div
+                                                v-if="questionDetails.data.type == 'Choices'"
+                                                v-for="index in SELECTION_SIZE"
+                                        >
 						<label
 							v-if="questionDetails.data[`option_${index}`]"
 							class="flex items-center bg-surface-gray-3 rounded-md p-3 mt-4 w-full cursor-pointer focus:border-blue-600"
@@ -418,7 +421,12 @@ import ProgressBar from '@/components/ProgressBar.vue'
 const user = inject('$user')
 const activeQuestion = ref(0)
 const currentQuestion = ref('')
-const selectedOptions = reactive([0, 0, 0, 0])
+const SELECTION_SIZE = 5
+const selectedOptions = reactive(Array(SELECTION_SIZE).fill(0))
+const resetSelectedOptions = (values = []) => {
+        const next = Array.from({ length: SELECTION_SIZE }, (_, idx) => values[idx] || 0)
+        selectedOptions.splice(0, selectedOptions.length, ...next)
+}
 const showAnswers = reactive([])
 let questions = reactive([])
 const possibleAnswer = ref(null)
@@ -660,11 +668,11 @@ watch(
 )
 
 const startQuiz = () => {
-	localStorage.removeItem(quiz.data.title)
-	activeQuestion.value = 1
-	selectedOptions.splice(0, selectedOptions.length, ...[0, 0, 0, 0])
-	showAnswers.length = 0
-	possibleAnswer.value = null
+        localStorage.removeItem(quiz.data.title)
+        activeQuestion.value = 1
+        resetSelectedOptions()
+        showAnswers.length = 0
+        possibleAnswer.value = null
 
 	startTime = Date.now()
 	if (quiz.data.duration) startTimer()
@@ -673,11 +681,10 @@ const startQuiz = () => {
 }
 
 const markAnswer = (index) => {
-	if (!questionDetails.data.multiple)
-		selectedOptions.splice(0, selectedOptions.length, ...[0, 0, 0, 0])
-	selectedOptions[index - 1] = selectedOptions[index - 1] ? 0 : 1
-	if (selectedOptions.some((opt) => opt)) {
-		removeFromSkipped(activeQuestion.value)
+        if (!questionDetails.data.multiple) resetSelectedOptions()
+        selectedOptions[index - 1] = selectedOptions[index - 1] ? 0 : 1
+        if (selectedOptions.some((opt) => opt)) {
+                removeFromSkipped(activeQuestion.value)
 		if (!answeredQuestions.includes(activeQuestion.value))
 			answeredQuestions.push(activeQuestion.value)
 	} else {
@@ -705,17 +712,17 @@ const getAnswers = () => {
 
 const loadSavedAnswer = () => {
 	const quizData = JSON.parse(localStorage.getItem(quiz.data.title))
-	if (!quizData) return
-	const saved = quizData[activeQuestion.value - 1]
-	if (!saved) return
-	if (saved.type == 'Choices' && saved.selected) {
-		selectedOptions.splice(0, selectedOptions.length, ...saved.selected)
-		if (saved.selected.some((opt) => opt))
-			answeredQuestions.push(activeQuestion.value)
-	} else if (saved.type == 'User Input') {
-		possibleAnswer.value = saved.answer
-		if (saved.answer) answeredQuestions.push(activeQuestion.value)
-	}
+        if (!quizData) return
+        const saved = quizData[activeQuestion.value - 1]
+        if (!saved) return
+        if (saved.type == 'Choices' && Array.isArray(saved.selected)) {
+                resetSelectedOptions(saved.selected)
+                if (saved.selected.some((opt) => opt))
+                        answeredQuestions.push(activeQuestion.value)
+        } else if (saved.type == 'User Input') {
+                possibleAnswer.value = saved.answer
+                if (saved.answer) answeredQuestions.push(activeQuestion.value)
+        }
 }
 
 const removeFromSkipped = (num) => {
@@ -724,11 +731,11 @@ const removeFromSkipped = (num) => {
 }
 
 const loadQuestion = (num) => {
-	activeQuestion.value = num
-	selectedOptions.splice(0, selectedOptions.length, ...[0, 0, 0, 0])
-	showAnswers.length = 0
-	possibleAnswer.value = null
-	loadSavedAnswer()
+        activeQuestion.value = num
+        resetSelectedOptions()
+        showAnswers.length = 0
+        possibleAnswer.value = null
+        loadSavedAnswer()
 }
 
 const skipQuestion = () => {
@@ -869,11 +876,11 @@ const createSubmission = () => {
 }
 
 const resetQuiz = () => {
-	localStorage.removeItem(quiz.data.title)
-	activeQuestion.value = 0
-	selectedOptions.splice(0, selectedOptions.length, ...[0, 0, 0, 0])
-	showAnswers.length = 0
-	possibleAnswer.value = null
+        localStorage.removeItem(quiz.data.title)
+        activeQuestion.value = 0
+        resetSelectedOptions()
+        showAnswers.length = 0
+        possibleAnswer.value = null
 	quizSubmission.reset()
 	populateQuestions()
 	setupTimer()

--- a/lms/lms/doctype/lms_question/lms_question.json
+++ b/lms/lms/doctype/lms_question/lms_question.json
@@ -32,6 +32,11 @@
   "is_correct_4",
   "column_break_lknb",
   "explanation_4",
+  "section_break_kdho",
+  "option_5",
+  "is_correct_5",
+  "column_break_uzhw",
+  "explanation_5",
   "section_break_hkfe",
   "possibility_1",
   "possibility_3",
@@ -152,6 +157,31 @@
   },
   {
    "fieldname": "explanation_4",
+   "fieldtype": "Small Text",
+   "label": "Explanation"
+  },
+  {
+   "depends_on": "eval:doc.type == 'Choices'",
+   "fieldname": "section_break_kdho",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "option_5",
+   "fieldtype": "Small Text",
+   "label": "Option 5"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_correct_5",
+   "fieldtype": "Check",
+   "label": "Is Correct"
+  },
+  {
+   "fieldname": "column_break_uzhw",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "explanation_5",
    "fieldtype": "Small Text",
    "label": "Explanation"
   },

--- a/lms/lms/doctype/lms_question/lms_question.py
+++ b/lms/lms/doctype/lms_question/lms_question.py
@@ -26,7 +26,7 @@ def validate_correct_answers(question):
 def validate_duplicate_options(question):
 	options = []
 
-	for num in range(1, 5):
+	for num in range(1, 6):
 		if question.get(f"option_{num}"):
 			options.append(question.get(f"option_{num}"))
 
@@ -85,6 +85,7 @@ def get_correct_options(question):
 		"is_correct_2",
 		"is_correct_3",
 		"is_correct_4",
+		"is_correct_5",
 	]
 	for field in correct_option_fields:
 		if question.get(field) == 1:
@@ -99,10 +100,12 @@ def get_question_details(question):
 		return
 
 	fields = ["question", "type", "name"]
-	for i in range(1, 5):
+	for i in range(1, 6):
 		fields.append(f"option_{i}")
 		fields.append(f"is_correct_{i}")
 		fields.append(f"explanation_{i}")
+
+	for i in range(1, 5):
 		fields.append(f"possibility_{i}")
 
 	return frappe.db.get_value("LMS Question", question, fields, as_dict=1)

--- a/lms/lms/doctype/lms_quiz/lms_quiz.py
+++ b/lms/lms/doctype/lms_quiz/lms_quiz.py
@@ -276,13 +276,15 @@ def save_progress_after_quiz(quiz_details, percentage):
 
 @frappe.whitelist()
 def get_question_details(question):
-	if frappe.db.exists("LMS Quiz Question", question):
-		fields = ["name", "question", "type"]
-		for num in range(1, 5):
-			fields.append(f"option_{cstr(num)}")
-			fields.append(f"is_correct_{cstr(num)}")
-			fields.append(f"explanation_{cstr(num)}")
-			fields.append(f"possibility_{cstr(num)}")
+        if frappe.db.exists("LMS Quiz Question", question):
+                fields = ["name", "question", "type"]
+                for num in range(1, 6):
+                        fields.append(f"option_{cstr(num)}")
+                        fields.append(f"is_correct_{cstr(num)}")
+                        fields.append(f"explanation_{cstr(num)}")
+
+                for num in range(1, 5):
+                        fields.append(f"possibility_{cstr(num)}")
 
 		return frappe.db.get_value("LMS Quiz Question", question, fields, as_dict=1)
 	return
@@ -298,18 +300,18 @@ def check_answer(question, type, answers):
 
 
 def check_choice_answers(question, answers):
-	fields = ["multiple"]
-	is_correct = []
-	for num in range(1, 5):
-		fields.append(f"option_{cstr(num)}")
-		fields.append(f"is_correct_{cstr(num)}")
+        fields = ["multiple"]
+        is_correct = []
+        for num in range(1, 6):
+                fields.append(f"option_{cstr(num)}")
+                fields.append(f"is_correct_{cstr(num)}")
 
-	question_details = frappe.db.get_value("LMS Question", question, fields, as_dict=1)
+        question_details = frappe.db.get_value("LMS Question", question, fields, as_dict=1)
 
-	for num in range(1, 5):
-		if question_details[f"option_{num}"] in answers:
-			is_correct.append(question_details[f"is_correct_{num}"])
-		elif question_details[f"is_correct_{num}"]:
+        for num in range(1, 6):
+                if question_details[f"option_{num}"] in answers:
+                        is_correct.append(question_details[f"is_correct_{num}"])
+                elif question_details[f"is_correct_{num}"]:
 			is_correct.append(2)
 		else:
 			is_correct.append(0)

--- a/lms/lms/utils.py
+++ b/lms/lms/utils.py
@@ -1440,10 +1440,10 @@ def get_country_code():
 
 @frappe.whitelist()
 def get_question_details(question):
-	fields = ["question", "type", "multiple"]
-	for i in range(1, 5):
-		fields.append(f"option_{i}")
-		fields.append(f"explanation_{i}")
+        fields = ["question", "type", "multiple"]
+        for i in range(1, 6):
+                fields.append(f"option_{i}")
+                fields.append(f"explanation_{i}")
 
 	question_details = frappe.db.get_value("LMS Question", question, fields, as_dict=1)
 	return question_details

--- a/lms/patches/v1_0/create_quiz_questions.py
+++ b/lms/patches/v1_0/create_quiz_questions.py
@@ -4,12 +4,14 @@ import frappe
 def execute():
 	frappe.reload_doc("lms", "doctype", "lms_question")
 
-	fields = ["name", "question", "type", "multiple"]
-	for num in range(1, 5):
-		fields.append(f"option_{num}")
-		fields.append(f"is_correct_{num}")
-		fields.append(f"explanation_{num}")
-		fields.append(f"possibility_{num}")
+        fields = ["name", "question", "type", "multiple"]
+        for num in range(1, 6):
+                fields.append(f"option_{num}")
+                fields.append(f"is_correct_{num}")
+                fields.append(f"explanation_{num}")
+
+        for num in range(1, 5):
+                fields.append(f"possibility_{num}")
 
 	questions = frappe.get_all(
 		"LMS Quiz Question",
@@ -26,16 +28,19 @@ def execute():
 			}
 		)
 
-		for num in range(1, 5):
-			if question.get(f"option_{num}"):
-				doc.update(
-					{
-						f"option_{num}": question[f"option_{num}"],
-						f"is_correct_{num}": question[f"is_correct_{num}"],
-						f"explanation_{num}": question[f"explanation_{num}"],
-						f"possibility_{num}": question[f"possibility_{num}"],
-					}
-				)
+                for num in range(1, 6):
+                        if question.get(f"option_{num}"):
+                                doc.update(
+                                        {
+                                                f"option_{num}": question[f"option_{num}"],
+                                                f"is_correct_{num}": question[f"is_correct_{num}"],
+                                                f"explanation_{num}": question[f"explanation_{num}"],
+                                        }
+                                )
+
+                for num in range(1, 5):
+                        if question.get(f"possibility_{num}"):
+                                doc.update({f"possibility_{num}": question[f"possibility_{num}"]})
 
 		doc.save()
 		frappe.db.set_value("LMS Quiz Question", question.name, "question", doc.name)

--- a/lms/plugins.py
+++ b/lms/plugins.py
@@ -114,10 +114,12 @@ def quiz_renderer(quiz_name):
 	)
 	quiz.questions = []
 	fields = ["name", "question", "type", "multiple"]
-	for num in range(1, 5):
+	for num in range(1, 6):
 		fields.append(f"option_{num}")
 		fields.append(f"is_correct_{num}")
 		fields.append(f"explanation_{num}")
+
+	for num in range(1, 5):
 		fields.append(f"possibility_{num}")
 
 	questions = frappe.get_all(


### PR DESCRIPTION
## Summary
- expand LMS Question DocType with fifth option/explanation fields and update backend helpers to process them
- update quiz APIs and renderer so question details and answer checks return five choice slots
- extend quiz play and authoring components to render and persist a fifth choice option

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f151178908329a10cac9679af0510)